### PR TITLE
Added `carpentries/` dir

### DIFF
--- a/carpentries/carpentries_instructors.tsv
+++ b/carpentries/carpentries_instructors.tsv
@@ -1,0 +1,53 @@
+name	institution	city	status	country
+Laurent Gatto	UCLouvain	Brussels	Certified	Belgium
+Charlotte Soneson	Friedrich Miescher Institute for Biomedical Research	Basel	Certified	Switzerland
+Kevin Rue-Albrecht	University of Oxford	Oxford	Certified	United Kingdom
+Robert Castelo	Pompeu Fabra University	Barcelona	Certified	Spain
+Kozo Nishida	Tokyo University of Agriculture and Technology	Tokyo	Certified	Japan
+Peter Hickey	WEHI	Melbourne	Certified	Australia
+Saskia Freytag	WEHI	Melbourne	Certified	Australia
+Helen Lindsay	CHUV	Lausanne	Certified	Switzerland
+Jenny Drnevich	University of Illinois	Urbana	Certified	United States
+Pariksheet Nanda	University of Michigan Medical School	Ann Arbor	Certified	United States
+Marcel Ramos	CUNY	New York	Certified	United States
+Liz Ing-Simmons	MRC London Institute of Medical Sciences	London	Certified	United Kingdom
+Nitesh Turaga	Bioconductor Community	Buffalo	Certified	United States
+Lisa Breckels	University of Cambridge	Cambridge	Certified	United States
+Kayla Interdonato	Roswell Park Comprehensive Cancer Center	Buffalo	Certified	United States
+Mikhail Dozmorov	Virginia Commonwealth University	Richmond	Certified	United States
+Susan Holmes	Stanford University	Stanford	Certified	United States
+Sonia Barasa	Pan-African Mosquito Control Association (PAMCA)	Nairobi	Certified	Kenya
+Maureen Osano	Kenya Medical Research Institute (KEMRI)	Nairobi	Certified	Kenya
+Javier Carpinteyro-Ponce	Carnegie Institution for Science	Maryland	Certified	United States
+Fabricio Almeida-Silva	VIB-UGent Center for Plant Systems Biology	Ghent	Certified - CZI Year 1	Belgium
+Anand Ruban Agarvas	University Hospital Heidelberg	Heidelberg	Certified - CZI Year 1	Germany
+Oliver Crook	University of Oxford	Oxford	Certified - CZI Year 1	United Kingdom
+Almut Lütge	University of Zürich	Zurich	Certified - CZI Year 1	Switzerland
+Leo Lahti	University of Turku	Turku	Certified - CZI Year 1	Finland
+Sehyun Oh	City University of New York	New York	Certified - CZI Year 1	United States
+Umar Ahmad	Bauchi State University	Gadau	In Progress	Nigeria
+Chia Sin Liew	University of Nebraska-Lincoln	Nebraska	Certified - CZI Year 1	United States
+Charlotte Hutchings	University of Cambridge	Cambridge	Certified - CZI Year 1	United States
+Roberto Carlos Álvarez Martínez	Universidad Autonoma de Queretaro	Mexico	In Progress	Mexico
+David Shih	University of Hong Kong	Hong Kong	Certified - CZI Year 1	China
+Rodrigo Arcoverde Cerveira da Silva	Karolinska Institute	Stockholm	Certified - CZI Year 1	Sweden
+Javier Carpinteyro Ponce	University of Maryland	Maryland	Certified - CZI Year 1	United States
+Zuguang Gu	German Cancer Research Center	Heidelberg	Certified - CZI Year 1	Germany
+Givanna Putri	Walter and Eliza Hall Institute of Medical Research	Melbourne	Certified - CZI Year 1	Australia
+Zedias Chikwambi	Chinhoyi University of Technology	Chinhoyi	Certified - CZI Year 1	Zimbabwe
+Pageneck Chikondowa	African Institute of Biomedical Science and Technology	Harare	Certified - CZI Year 1	Zimbabwe
+Marie Hidjo	African Institute of Biomedical Science and Technology	Harare	Certified - CZI Year 1	Zimbabwe
+Kevin Stachelek	University of Southern California	Los Angeles	In Progress	United States
+Erick Isaac Navarro Delgado	University of British Columbia	Vancouver	In Progress	Canada
+Pedro Baldoni	Walter and Eliza Hall Institute of Medical Research	Melbourne	Certified - CZI Year 2	Australia
+Princess Rodriguez	University of Vermont	Burlington	In Progress	United States
+Tim Triche	Van Andel Institute	Grand Rapids	Certified - CZI Year 2	United States
+Izabela Mamede	Universidade Federal de Minas Gerais	Belo Horizonte	Certified - CZI Year 2	Brazil
+Jacques Serizay	Institut Pasteur	Paris	In Progress	France
+Robert Ivanek	University of Basel, Swiss Institute of Bioinformatics	Basel	Certified - CZI Year 2	Switzerland
+Hamdi Furkan Kepenek	Abdullah Gül University	Kayseri	In Progress	Turkey
+陈秭如	GuangZhou Lab	Guangzhou	In Progress	China
+Amal Boukteb	National Institute for Agricultural Research of Tunisia (INRAT)	Tunis	Certified - CZI Year 2	Tunisia
+Arnab Mukherjee	Manipal Institute of Technology	Manipal	Certified - CZI Year 2	India
+Harvinder Singh	Department of Translational and Regenerative Medicine, PGIMER	Chandigarh	In Progress	India
+Janani Ravi	University of Colorado Anschutz Medical Campus	Aurora	In Progress	United States

--- a/carpentries/carpentries_workshops.tsv
+++ b/carpentries/carpentries_workshops.tsv
@@ -1,0 +1,20 @@
+date	hosted_by	workshop	city	instructors	country
+March 2024	University of Illinois	bioc-intro	Champaign	Jenny Drnevich, Negin Valizadegan, Yifei Kang	United States
+November 2023	Instituto Evandro Chagas	bioc-rnaseq	Belém	Rodrigo Arcoverde Cerveira da Silva	Brazil
+15 October 2023	BioCAsia2023	bioc-rnaseq	Hong Kong	David Shih	China
+12-13 October 2023	Carnegie Institution	bioc-rnaseq	Baltimore	Javier Carpinteyro-Ponce, Frederick Tan	United States
+9-12 October 2023	University of Bergen	bioc-intro	Bergen	Leo Lahti	Norway
+October 2023	University of Illinois	bioc-intro	Champaign	Jenny Drnevich, Jessica Holmes, Yifei Kang	United States
+18-19 September 2023	EuroBioC2023	bioc-rnaseq	Ghent	Soneson Charlotte, Almut Lütge, Fabricio Almeida-Silva	Belgium
+18-19 September 2023	EuroBioC2023	bioc-intro	Ghent	Laurent Gatto, Charlotte Hutchings, Olly Crook, Givanna Putri, Marcel Ramos Pérez	Belgium
+31 July-1 August 2023	BioC2023	bioc-intro	Boston	Jenny Drnevich, Sehyun Oh	United States
+19-21 June 2023	University of Oulu	bioc-intro	Oulu	Leo Lahti	Finland
+March 2023	University of Illinois	bioc-intro	Champaign	Jenny Drnevich, Jessica Holmes, Negin Valizadegan	United States
+March 2023	UCLouvain	bioc-intro	Brussels	Laurent Gatto	Belgium
+21-24 Feb 2023	Savitribai Phule Pune University	bioc-intro	Pune	Leo Lahti	India
+2023	NA	bioc-intro	Uzhhorod	Laurent Gatto	Ukraine
+12-13 September 2022	EuroBioC2022	bioc-intro	Heidelberg	Charlotte Soneson, Laurent Gatto	Germany
+2022	UCLouvain	bioc-intro	Brussels	Laurent Gatto	Belgium
+July 2024	BioC2024	bioc-rnaseq	Grand Rapids	Jenny Drnevich, Tim Triche, Charllote Hutchings	United States
+September 2024	EuroBioC2024	bioc-intro	Oxford	Oliver Crook, Marcel Ramos-Perez	United Kingdom
+September 2024	EuroBioC2024	bioc-rnaseq	Oxford	Fabricio Almeida-Silva, Robert Ivanek	United Kingdom


### PR DESCRIPTION
Hi, all

As we've discussed recently (@csoneson, @mblue9), it would be nice to have all data on Bioconductor Carpentries workshops and certified instructors in a centralized, official repo.

I added a folder named `carpentries/` with two .tsv files that we can use to keep data up to date. As new data come in, we would simply submit a PR with the same tables, but with appended rows. I believe this makes long-term maintenance much easier.